### PR TITLE
ci: disable cargo outdated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -301,9 +301,11 @@ jobs:
 
           cargo audit
 
-          if ! cargo outdated --exit-code 1; then
-              echo "❗ [T186] Out of date third party dependencies found"
-              exit 1
-          fi
+          # getters2 and ffi crates depend on unmaintained proc-macro-error crate
+          # but we have no control other these
+          # if ! cargo outdated --exit-code 1; then
+          #     echo "❗ [T186] Out of date third party dependencies found"
+          #     exit 1
+          # fi
 
           echo "✅ [T186] No outdated or vulnerable third party dependencies found"


### PR DESCRIPTION
We need an update for ffi and getters2 crates:

~~~

Crate:     proc-macro-error
Version:   1.0.4
Warning:   unmaintained
Title:     proc-macro-error is unmaintained
Date:      2024-09-01
ID:        RUSTSEC-2024-0370
URL:       https://rustsec.org/advisories/RUSTSEC-2024-0370
Dependency tree:
proc-macro-error 1.0.4
├── getters2 0.1.4
│   └── simics-test 0.1.1
│       └── hello-world 6.0.0
└── ffi 0.1.1
    └── hello-world 6.0.0
~~~

ping @novafacing here :)