### PR TITLE
Speed up the build via opt-level = 3 build-override

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,3 +77,9 @@ lto = true
 codegen-units = 1
 opt-level = 3
 debug = true
+
+[profile.dev.build-override]
+opt-level = 3
+
+[profile.release.build-override]
+opt-level = 3


### PR DESCRIPTION
The simics-api-sys build script takes around 5 minutes to run against
the installation of Simics 7.70.0 on my laptop, and building this
script with optimizations enabled (opt-level = 3) takes that down to
about 25 seconds, so that is probably worth doing.