### PR TITLE
cargo: release v0.2.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [workspace.package]
-version = "0.2.5"
+version = "0.2.6"
 authors = ["Rowan Hart <rowan.hart@intel.com>"]
 # https://crates.io/category_slugs
 categories = [
@@ -53,16 +53,16 @@ default-members = [
 exclude = []
 
 [workspace.dependencies]
-cargo-simics-build = { version = "0.2.5", path = "cargo-simics-build" }
-ispm-wrapper = { version = "0.2.5", path = "ispm-wrapper" }
-simics-api-sys = { version = "0.2.5", path = "simics-api-sys" }
-simics-macro = { version = "0.2.5", path = "simics-macro" }
-simics = { version = "0.2.5", path = "simics" }
-simics-sign = { version = "0.2.5", path = "simics-sign" }
-simics-package = { version = "0.2.5", path = "simics-package" }
-simics-python-utils = { version = "0.2.5", path = "simics-python-utils" }
-simics-test = { version = "0.2.5", path = "simics-test" }
-simics-build-utils = { version = "0.2.5", path = "simics-build-utils" }
+cargo-simics-build = { version = "0.2.6", path = "cargo-simics-build" }
+ispm-wrapper = { version = "0.2.6", path = "ispm-wrapper" }
+simics-api-sys = { version = "0.2.6", path = "simics-api-sys" }
+simics-macro = { version = "0.2.6", path = "simics-macro" }
+simics = { version = "0.2.6", path = "simics" }
+simics-sign = { version = "0.2.6", path = "simics-sign" }
+simics-package = { version = "0.2.6", path = "simics-package" }
+simics-python-utils = { version = "0.2.6", path = "simics-python-utils" }
+simics-test = { version = "0.2.6", path = "simics-test" }
+simics-build-utils = { version = "0.2.6", path = "simics-build-utils" }
 
 [profile.dev]
 # NOTE: rparth set to true to allow cargo test/cargo run to find libsimics-common,

--- a/cargo-simics-build/Cargo.toml
+++ b/cargo-simics-build/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "cargo-simics-build"
-version = "0.2.5"
+version = "0.2.6"
 authors = ["Rowan Hart <rowan.hart@intel.com>"]
 edition = "2021"
 description = "Build utility for Intel® Simics® Simulator modules"

--- a/ispm-wrapper/Cargo.toml
+++ b/ispm-wrapper/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "ispm-wrapper"
-version = "0.2.5"
+version = "0.2.6"
 authors = ["Rowan Hart <rowan.hart@intel.com>"]
 edition = "2021"
 description = "Wrappers for Intel® Simics® Package Manager commands"

--- a/simics-api-sys/Cargo.toml
+++ b/simics-api-sys/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "simics-api-sys"
-version = "0.2.5"
+version = "0.2.6"
 authors = ["Rowan Hart <rowan.hart@intel.com>"]
 edition = "2021"
 description = "Automatically generated Intel® Simics® Simulator FFI bindings"

--- a/simics-build-utils/Cargo.toml
+++ b/simics-build-utils/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "simics-build-utils"
-version = "0.2.5"
+version = "0.2.6"
 authors = ["Rowan Hart <rowan.hart@intel.com>"]
 edition = "2021"
 description = "Intel® Simics® Simulator build and linking utilities"

--- a/simics-macro/Cargo.toml
+++ b/simics-macro/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "simics-macro"
-version = "0.2.5"
+version = "0.2.6"
 authors = ["Rowan Hart <rowan.hart@intel.com>"]
 edition = "2021"
 description = "Proc macros for building Intel® Simics® Simulator modules"

--- a/simics-package/Cargo.toml
+++ b/simics-package/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "simics-package"
-version = "0.2.5"
+version = "0.2.6"
 authors = ["Rowan Hart <rowan.hart@intel.com>"]
 edition = "2021"
 description = "Intel® Simics® Simulator module packaging tools"

--- a/simics-sign/Cargo.toml
+++ b/simics-sign/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "simics-sign"
-version = "0.2.5"
+version = "0.2.6"
 authors = ["Rowan Hart <rowan.hart@intel.com>"]
 edition = "2021"
 description = "Intel® Simics® Simulator module signing tools"

--- a/simics-test/Cargo.toml
+++ b/simics-test/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "simics-test"
-version = "0.2.5"
+version = "0.2.6"
 authors = ["Rowan Hart <rowan.hart@intel.com>"]
 edition = "2021"
 description = "Intel Simics Simulator module testing tools"

--- a/simics/Cargo.toml
+++ b/simics/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "simics"
-version = "0.2.5"
+version = "0.2.6"
 authors = ["Rowan Hart <rowan.hart@intel.com>"]
 edition = "2021"
 description = "Intel® Simics® Simulator bindings in high level, idiomatic Rust"


### PR DESCRIPTION
## Summary
- Bump all crate versions from 0.2.5 to 0.2.6

## Release
After merge, tag `v0.2.6` and push to trigger crates.io publish and GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)