### PR TITLE
ci: fix create_release job missing checkout step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -81,6 +81,13 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
       - name: Create GitHub Release
         run: gh release create ${{ github.ref_name }} --generate-notes
         env:


### PR DESCRIPTION
## Summary
- Add missing `actions/checkout` step to the `create_release` job in the publish workflow

## Problem
The `create_release` job was failing because `gh release create` requires a git repository, but the job didn't check out the code.

Failure from v0.2.6 release:
https://github.com/intel/simulator-bindings/actions/runs/24831255075/job/72690210113

```
Run gh release create v0.2.6 --generate-notes
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

## Changes
- Added `step-security/harden-runner` step (consistent with other jobs)
- Added `actions/checkout` step before running `gh release create`

🤖 Generated with [Claude Code](https://claude.com/claude-code)